### PR TITLE
Use RFC9000 varint encoding for mv TXT record field

### DIFF
--- a/openscreen-common/Cargo.toml
+++ b/openscreen-common/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+bytes = { version = "1", default-features = false }
 heapless = "0.8"
 
 [lints]

--- a/openscreen-common/src/lib.rs
+++ b/openscreen-common/src/lib.rs
@@ -20,6 +20,7 @@
 //! (authentication) and the OpenScreen Application Protocol (presentations, agent info).
 
 mod error;
+pub mod quinn_varint;
 mod types;
 
 pub use error::*;

--- a/openscreen-common/src/quinn_varint/mod.rs
+++ b/openscreen-common/src/quinn_varint/mod.rs
@@ -1,0 +1,46 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Variable-length integer encoding as specified in RFC 9000 (QUIC).
+//!
+//! This module contains code vendored from the [quinn](https://github.com/quinn-rs/quinn)
+//! project's `quinn-proto` crate, with minimal modifications for `no_std` compatibility.
+
+mod varint;
+
+pub use varint::{VarInt, VarIntBoundsExceeded};
+
+use bytes::{Buf, BufMut};
+
+/// Error indicating that the provided buffer was too small.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct UnexpectedEnd;
+
+impl core::fmt::Display for UnexpectedEnd {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "unexpected end of buffer")
+    }
+}
+
+/// Coding result type.
+pub type Result<T> = core::result::Result<T, UnexpectedEnd>;
+
+/// Trait for encoding and decoding QUIC primitives.
+pub trait Codec: Sized {
+    /// Decode a value from the provided buffer.
+    fn decode<B: Buf>(buf: &mut B) -> Result<Self>;
+
+    /// Encode this value into the provided buffer.
+    fn encode<B: BufMut>(&self, buf: &mut B);
+}

--- a/openscreen-common/src/quinn_varint/varint.rs
+++ b/openscreen-common/src/quinn_varint/varint.rs
@@ -1,0 +1,215 @@
+// Vendored from quinn-proto (https://github.com/quinn-rs/quinn)
+// Original file: quinn-proto/src/varint.rs
+//
+// Copyright (c) 2018 The quinn Developers
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+// Modifications:
+// - Adapted for no_std (std:: -> core::)
+// - Removed thiserror dependency
+// - Removed arbitrary feature
+
+use core::{convert::TryInto, fmt};
+
+use bytes::{Buf, BufMut};
+
+use super::{Codec, UnexpectedEnd};
+
+/// An integer less than 2^62
+///
+/// Values of this type are suitable for encoding as QUIC variable-length integer.
+// It would be neat if we could express to Rust that the top two bits are available for use as enum
+// discriminants
+#[derive(Default, Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct VarInt(pub(crate) u64);
+
+impl VarInt {
+    /// The largest representable value
+    pub const MAX: Self = Self((1 << 62) - 1);
+    /// The largest encoded value length
+    pub const MAX_SIZE: usize = 8;
+
+    /// Construct a `VarInt` infallibly
+    pub const fn from_u32(x: u32) -> Self {
+        Self(x as u64)
+    }
+
+    /// Succeeds iff `x` < 2^62
+    pub fn from_u64(x: u64) -> Result<Self, VarIntBoundsExceeded> {
+        if x < 2u64.pow(62) {
+            Ok(Self(x))
+        } else {
+            Err(VarIntBoundsExceeded)
+        }
+    }
+
+    /// Create a VarInt without ensuring it's in range
+    ///
+    /// # Safety
+    ///
+    /// `x` must be less than 2^62.
+    pub const unsafe fn from_u64_unchecked(x: u64) -> Self {
+        Self(x)
+    }
+
+    /// Extract the integer value
+    pub const fn into_inner(self) -> u64 {
+        self.0
+    }
+
+    /// Compute the number of bytes needed to encode this value
+    pub const fn size(self) -> usize {
+        let x = self.0;
+        if x < 2u64.pow(6) {
+            1
+        } else if x < 2u64.pow(14) {
+            2
+        } else if x < 2u64.pow(30) {
+            4
+        } else if x < 2u64.pow(62) {
+            8
+        } else {
+            panic!("malformed VarInt");
+        }
+    }
+}
+
+impl From<VarInt> for u64 {
+    fn from(x: VarInt) -> Self {
+        x.0
+    }
+}
+
+impl From<u8> for VarInt {
+    fn from(x: u8) -> Self {
+        Self(x.into())
+    }
+}
+
+impl From<u16> for VarInt {
+    fn from(x: u16) -> Self {
+        Self(x.into())
+    }
+}
+
+impl From<u32> for VarInt {
+    fn from(x: u32) -> Self {
+        Self(x.into())
+    }
+}
+
+impl core::convert::TryFrom<u64> for VarInt {
+    type Error = VarIntBoundsExceeded;
+    /// Succeeds iff `x` < 2^62
+    fn try_from(x: u64) -> Result<Self, VarIntBoundsExceeded> {
+        Self::from_u64(x)
+    }
+}
+
+impl core::convert::TryFrom<u128> for VarInt {
+    type Error = VarIntBoundsExceeded;
+    /// Succeeds iff `x` < 2^62
+    fn try_from(x: u128) -> Result<Self, VarIntBoundsExceeded> {
+        Self::from_u64(x.try_into().map_err(|_| VarIntBoundsExceeded)?)
+    }
+}
+
+impl core::convert::TryFrom<usize> for VarInt {
+    type Error = VarIntBoundsExceeded;
+    /// Succeeds iff `x` < 2^62
+    fn try_from(x: usize) -> Result<Self, VarIntBoundsExceeded> {
+        Self::try_from(x as u64)
+    }
+}
+
+impl fmt::Debug for VarInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl fmt::Display for VarInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// Error returned when constructing a `VarInt` from a value >= 2^62
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct VarIntBoundsExceeded;
+
+impl fmt::Display for VarIntBoundsExceeded {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "value too large for varint encoding")
+    }
+}
+
+impl Codec for VarInt {
+    fn decode<B: Buf>(r: &mut B) -> super::Result<Self> {
+        if !r.has_remaining() {
+            return Err(UnexpectedEnd);
+        }
+        let mut buf = [0; 8];
+        buf[0] = r.get_u8();
+        let tag = buf[0] >> 6;
+        buf[0] &= 0b0011_1111;
+        let x = match tag {
+            0b00 => u64::from(buf[0]),
+            0b01 => {
+                if r.remaining() < 1 {
+                    return Err(UnexpectedEnd);
+                }
+                r.copy_to_slice(&mut buf[1..2]);
+                u64::from(u16::from_be_bytes(buf[..2].try_into().unwrap()))
+            }
+            0b10 => {
+                if r.remaining() < 3 {
+                    return Err(UnexpectedEnd);
+                }
+                r.copy_to_slice(&mut buf[1..4]);
+                u64::from(u32::from_be_bytes(buf[..4].try_into().unwrap()))
+            }
+            0b11 => {
+                if r.remaining() < 7 {
+                    return Err(UnexpectedEnd);
+                }
+                r.copy_to_slice(&mut buf[1..8]);
+                u64::from_be_bytes(buf)
+            }
+            _ => unreachable!(),
+        };
+        Ok(Self(x))
+    }
+
+    fn encode<B: BufMut>(&self, w: &mut B) {
+        let x = self.0;
+        if x < 2u64.pow(6) {
+            w.put_u8(x as u8);
+        } else if x < 2u64.pow(14) {
+            w.put_u16((0b01 << 14) | x as u16);
+        } else if x < 2u64.pow(30) {
+            w.put_u32((0b10 << 30) | x as u32);
+        } else if x < 2u64.pow(62) {
+            w.put_u64((0b11 << 62) | x);
+        } else {
+            unreachable!("malformed VarInt")
+        }
+    }
+}

--- a/openscreen-common/tests/varint.rs
+++ b/openscreen-common/tests/varint.rs
@@ -1,0 +1,58 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the vendored VarInt (RFC 9000 variable-length integer) implementation.
+
+use openscreen_common::quinn_varint::{Codec, VarInt};
+
+#[test]
+fn test_varint_encode_decode_roundtrip() {
+    // Test various values using the vendored VarInt
+    for value in [0u32, 1, 42, 63, 64, 100, 16383, 16384, 1000000] {
+        let varint = VarInt::from_u32(value);
+        let mut encoded = Vec::new();
+        varint.encode(&mut encoded);
+
+        let mut slice: &[u8] = &encoded;
+        let decoded = VarInt::decode(&mut slice).unwrap();
+        assert_eq!(
+            decoded.into_inner() as u32,
+            value,
+            "Roundtrip failed for value {value}"
+        );
+    }
+}
+
+#[test]
+fn test_varint_encoding_format() {
+    // Value 0: single byte 0x00
+    let mut buf = Vec::new();
+    VarInt::from_u32(0).encode(&mut buf);
+    assert_eq!(buf, vec![0x00]);
+
+    // Value 42: single byte 0x2A
+    buf.clear();
+    VarInt::from_u32(42).encode(&mut buf);
+    assert_eq!(buf, vec![42]);
+
+    // Value 63: single byte 0x3F (max for 1-byte)
+    buf.clear();
+    VarInt::from_u32(63).encode(&mut buf);
+    assert_eq!(buf, vec![0x3F]);
+
+    // Value 64: two bytes 0x40 0x40
+    buf.clear();
+    VarInt::from_u32(64).encode(&mut buf);
+    assert_eq!(buf, vec![0x40, 0x40]);
+}

--- a/openscreen-discovery-mdns/Cargo.toml
+++ b/openscreen-discovery-mdns/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
+openscreen-common = { path = "../openscreen-common" }
 openscreen-discovery = { path = "../openscreen-discovery" }
 async-trait = "0.1"
 futures = "0.3"

--- a/openscreen-discovery-mdns/src/publisher.rs
+++ b/openscreen-discovery-mdns/src/publisher.rs
@@ -119,7 +119,7 @@ impl DiscoveryPublisher for MdnsPublisher {
             &hostname,
             (), // addresses (will be auto-detected)
             info.port,
-            Some(properties),
+            properties,
         )
         .map_err(|e| DiscoveryError::PublishFailed(format!("Failed to create service info: {e}")))?
         .enable_addr_auto();


### PR DESCRIPTION
 ## Summary

Implements RFC9000 (QUIC) variable-length integer encoding for the `mv` TXT record field as required by the W3C OpenScreen Protocol spec.

## Changes

- Vendor varint implementation from quinn-proto into `openscreen-common::quinn_varint` (adapted for `no_std`)
- In the `openscreen-common` since varint will also used in OSP message serialization.
- Update `build_txt_properties` to encode `mv` as RFC9000 varint bytes
- Update `parse_txt_properties` to decode `mv` from RFC9000 varint bytes

Fixes #1