### PR TITLE
Refactor: ServiceInfo.host->ip_address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ resolver = "2"
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.77"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/your-org/openscreen_rs_priv"
 

--- a/openscreen-application/src/bin/app-receiver.rs
+++ b/openscreen-application/src/bin/app-receiver.rs
@@ -156,7 +156,7 @@ async fn run_receiver(args: &Args) -> Result<()> {
 
     // Step 4: Start QUIC server
     let bind_addr = format!("0.0.0.0:{}", args.port)
-        .parse::<std::net::SocketAddr>()
+        .parse::<core::net::SocketAddr>()
         .context("Invalid bind address")?;
 
     println!("WAIT: Initializing QUIC server...");

--- a/openscreen-discovery-mock/src/backend.rs
+++ b/openscreen-discovery-mock/src/backend.rs
@@ -128,7 +128,7 @@ mod tests {
         ServiceInfo {
             instance_name: name.to_string(),
             display_name: name.to_string(),
-            host: "127.0.0.1".to_string(),
+            ip_address: std::net::Ipv4Addr::LOCALHOST.into(),
             port: 4433,
             fingerprint: Fingerprint::from_bytes([1u8; 32]),
             metadata_version: 1,

--- a/openscreen-discovery-mock/src/publisher.rs
+++ b/openscreen-discovery-mock/src/publisher.rs
@@ -55,7 +55,7 @@ impl DiscoveryPublisher for MockPublisher {
         let service_info = ServiceInfo {
             instance_name: info.display_name.clone(),
             display_name: info.display_name,
-            host: "127.0.0.1".to_string(), // Mock always uses localhost
+            ip_address: std::net::Ipv4Addr::LOCALHOST.into(), // Mock always uses localhost
             port: info.port,
             fingerprint: info.fingerprint,
             metadata_version: info.metadata_version,

--- a/openscreen-discovery/src/service_info.rs
+++ b/openscreen-discovery/src/service_info.rs
@@ -15,6 +15,7 @@
 //! Service information types
 
 use crate::{AuthToken, Fingerprint};
+use core::net::IpAddr;
 use std::time::SystemTime;
 
 /// A discovered OpenScreen service
@@ -32,8 +33,8 @@ pub struct ServiceInfo {
     /// Display name (decoded from instance name)
     pub display_name: String,
 
-    /// Hostname or IP address
-    pub host: String,
+    /// IP address (v4 or v6)
+    pub ip_address: IpAddr,
 
     /// Port number
     pub port: u16,
@@ -165,7 +166,7 @@ mod tests {
         let info1 = ServiceInfo {
             instance_name: "Device 1".to_string(),
             display_name: "Device 1".to_string(),
-            host: "192.168.1.1".to_string(),
+            ip_address: "192.168.1.1".parse().unwrap(),
             port: 4433,
             fingerprint: fp1,
             metadata_version: 1,
@@ -176,9 +177,9 @@ mod tests {
         let info2 = ServiceInfo {
             instance_name: "Device 1 (2)".to_string(), // Different name!
             display_name: "Device 1".to_string(),
-            host: "192.168.1.2".to_string(), // Different host!
-            port: 5544,                      // Different port!
-            fingerprint: fp1,                // Same fingerprint
+            ip_address: "192.168.1.2".parse().unwrap(), // Different ip!
+            port: 5544,                                 // Different port!
+            fingerprint: fp1,                           // Same fingerprint
             metadata_version: 2,
             auth_token: AuthToken::generate(),
             discovered_at: SystemTime::now(),
@@ -187,7 +188,7 @@ mod tests {
         let info3 = ServiceInfo {
             instance_name: "Device 1".to_string(),
             display_name: "Device 1".to_string(),
-            host: "192.168.1.1".to_string(),
+            ip_address: "192.168.1.1".parse().unwrap(),
             port: 4433,
             fingerprint: fp2, // Different fingerprint
             metadata_version: 1,


### PR DESCRIPTION
* Change ServiceInfo.host to be an IPAddr as that's how it's currently used.
* Refactor to make room for an actual hostname in #3